### PR TITLE
Remove formatting from the links in the Table of Content of the README

### DIFF
--- a/vision/README.md
+++ b/vision/README.md
@@ -48,6 +48,8 @@ Please see the readme files in sub-directories for more details.
 
 - To use the SmartHLS Vision library, you should first install the SmartHLS tool, which is part of the [Libero SoC Design Suite](https://www.microchip.com/en-us/products/fpgas-and-plds/fpga-and-soc-design-tools/fpga/libero-software-later-versions).
 
+`Note: This library is designed to work on the latest Libero SoC Design Suite version, 2023.1, and may not be compatible with previous versions of Libero and SmartHLS.`
+
 - Then clone this SmartHLS library repository,
   - We will do this in command line.  Windows users can [launch the Cygwin terminal](https://microchiptech.github.io/fpga-hls-docs/userguide.html#launch-cygwin-terminal-on-windows)
     in SmartHLS installation by opening `<SMARTHLS_INSTALLATION_DIR>/cygwin64/Cygwin.bat`.

--- a/vision/include/interface/README.md
+++ b/vision/include/interface/README.md
@@ -1,17 +1,17 @@
 <!-- TOC -->
 
 - [Configure Top-level RTL interface for Img arguments](#configure-top-level-rtl-interface-for-img-arguments)
-    - [**Memory interface** and **AXI4 Stream interface**](#memory-interface-and-axi4-stream-interface)
-    - [**AXI4 Initiator interface** and **AXI4 Target interface**](#axi4-initiator-interface-and-axi4-target-interface)
-        + [`AxiMM2Img()`](#aximm2img)
-        + [`Img2AxiMM()`](#img2aximm)
+    - [Memory interface and AXI4 Stream interface](#memory-interface-and-axi4-stream-interface)
+    - [AXI4 Initiator interface and AXI4 Target interface](#axi4-initiator-interface-and-axi4-target-interface)
+        + [AxiMM2Img()](#aximm2img)
+        + [Img2AxiMM()](#img2aximm)
     - [Mixed interfaces](#mixed-interfaces)
 - [AXI4-Stream Video Protocol](#axi4-stream-video-protocol)
     - [AXIS-Video vs FIFO-based vision::Img AXI4 Stream interface](#axis-video-vs-fifo-based-visionimg-axi4-stream-interface)
-    - [`AxisVideo2Img()`](#axisvideo2img)
-    - [`Img2AxisVideo()`](#img2axisvideo)
-    - [`AxiMM2AxisVideo()`](#aximm2axisvideo)
-    - [`AxisVideo2AxiMM()`](#axisvideo2aximm)
+    - [AxisVideo2Img()](#axisvideo2img)
+    - [Img2AxisVideo()](#img2axisvideo)
+    - [AxiMM2AxisVideo()](#aximm2axisvideo)
+    - [AxisVideo2AxiMM()](#axisvideo2aximm)
 
 <!-- /TOC -->
 # Configure Top-level RTL interface for `Img` arguments


### PR DESCRIPTION
This is because links with formatting requires double clicking on github.