### PR TITLE
Add a simple frame buffer control to the ddr_access_wrapper.

### DIFF
--- a/vision/demo_designs/PF_Video_kit/libero/src/hdl/ddr_access_wrapper.v
+++ b/vision/demo_designs/PF_Video_kit/libero/src/hdl/ddr_access_wrapper.v
@@ -49,6 +49,19 @@ module DDR_Access_wrapper_top # (
     output  VideoOut_last,
     output  VideoOut_user);
 
+wire writer_finish;
+wire [`MEMORY_CONTROLLER_ADDR_SIZE-1:0] wr_address;
+wire [`MEMORY_CONTROLLER_ADDR_SIZE-1:0] rd_address;
+
+FrameBufferControl (
+    .clk(clk),
+    .reset(reset),
+    .wr_finish(writer_finish),
+    .base_address(buf_var),
+    .wr_address(wr_address),
+    .rd_address(rd_address)
+);
+
 DDR_Write_wrapper_top # (
     .ADDR_WIDTH(ADDR_WIDTH),
     .AXI_DATA_WIDTH(AXI_DATA_WIDTH),
@@ -57,7 +70,8 @@ DDR_Write_wrapper_top # (
     .clk(clk),
     .reset(reset),
     .start(start_write),
-    .Buf(buf_var),
+    .finish(writer_finish),
+    .Buf(wr_address),
     .HRes(hres),
     .VRes(vres),
     .axi4initiator_aw_addr(axi4initiator_aw_addr),
@@ -91,7 +105,7 @@ DDR_Read_wrapper_top # (
   .clk(clk),
   .reset(reset),
   .start(start_read),
-  .Buf(buf_var),
+  .Buf(rd_address),
   .HRes(hres),
   .VRes(vres),
   .axi4initiator_ar_addr(axi4initiator_ar_addr),
@@ -111,5 +125,43 @@ DDR_Read_wrapper_top # (
   .VideoOut_last(VideoOut_last),
   .VideoOut_user(VideoOut_user)
 );
+
+endmodule
+
+// Each time the DDR writer finishes writing a frame to DDR, FrameBufferControl
+// provides a new address for the DDR writer to write the next frame, and
+// provides to the DDR reader with the address of latest frame (the frame that
+// just got written to DDR by DDR writer).
+// The number of frames and each frame's byte size can be parameterized.
+module FrameBufferControl # (
+    parameter NUM_BUFFERS = 4,
+    parameter BUFFER_SIZE = (1 << 23)  // 8 Mbytes.
+) (
+    input clk,
+    input reset,
+    input wr_finish,
+    input [31:0] base_address,
+    output reg [31:0] wr_address,
+    output reg [31:0] rd_address
+);
+
+reg [7:0] wr_idx_count = 0;
+
+always @ (posedge clk) begin
+    if (reset) begin
+        wr_idx_count <= 0;
+        wr_address <= base_address;
+        rd_address <= base_address;
+    end else if (wr_finish) begin
+        rd_address <= wr_address;
+        if (wr_idx_count == NUM_BUFFERS - 1) begin
+            wr_idx_count <=  0;
+            wr_address <= base_address;
+        end else begin
+            wr_idx_count <= wr_idx_count + 1;
+            wr_address <= wr_address + BUFFER_SIZE;
+        end
+    end
+end
 
 endmodule

--- a/vision/include/imgproc/README.md
+++ b/vision/include/imgproc/README.md
@@ -23,13 +23,13 @@
 ## RGB <--> Grayscale
 ### `RGB2GRAY()`
 ```cpp
-template <bool NTSC = true, PixelType PIXEL_T_I, PixelType PIXEL_T_O,
-          unsigned H, unsigned W, StorageType STORAGE_I = FIFO,
-          StorageType STORAGE_O = FIFO, NumPixelsPerCycle NPPC = NPPC_1>
-void RGB2GRAY(vision::Img<PIXEL_T_I, H, W, STORAGE_I, NPPC> &ImgIn,
-              vision::Img<PIXEL_T_O, H, W, STORAGE_O, NPPC> &ImgOut)
+template <bool NTSC = true, PixelType PIXEL_T_IN, PixelType PIXEL_T_OUT,
+          unsigned H, unsigned W, StorageType STORAGE_IN = FIFO,
+          StorageType STORAGE_OUT = FIFO, NumPixelsPerCycle NPPC = NPPC_1>
+void RGB2GRAY(vision::Img<PIXEL_T_IN, H, W, STORAGE_IN, NPPC> &InImg,
+              vision::Img<PIXEL_T_OUT, H, W, STORAGE_OUT, NPPC> &OutImg)
 ```
-This functions converts an input three-channel RGB `ImgIn` to an output single-channel grayscale `ImgOut`.
+This functions converts an input three-channel RGB `InImg` to an output single-channel grayscale `OutImg`.
 
 **Template parameters:**
 - `NTSC`: whether to use the [NTSC](https://en.wikipedia.org/wiki/NTSC) formula or not (the default value is `true`).
@@ -48,15 +48,15 @@ vision::RGB2GRAY<false>(InImg, OutImg3); // Explicitly do not use the NTSC formu
 
 ### `GRAY2RGB()`
 ```cpp
-template <PixelType PIXEL_T_I, PixelType PIXEL_T_O, unsigned H, unsigned W,
-          StorageType STORAGE_I = FIFO, StorageType STORAGE_O = FIFO,
+template <PixelType PIXEL_T_IN, PixelType PIXEL_T_OUT, unsigned H, unsigned W,
+          StorageType STORAGE_IN = FIFO, StorageType STORAGE_OUT = FIFO,
           NumPixelsPerCycle NPPC = NPPC_1>
-void GRAY2RGB(vision::Img<PIXEL_T_I, H, W, STORAGE_I, NPPC> &ImgIn,
-              vision::Img<PIXEL_T_O, H, W, STORAGE_O, NPPC> &ImgOut)
+void GRAY2RGB(vision::Img<PIXEL_T_IN, H, W, STORAGE_IN, NPPC> &InImg,
+              vision::Img<PIXEL_T_OUT, H, W, STORAGE_OUT, NPPC> &OutImg)
 ```
-This function takes in an input single-channel grayscale `ImgIn`.
-The resulting output `ImgOut` is still visually the same grayscale image but represented in RGB format.
-In other words, for each pixel in `ImgOut`, the `R`, `G`, and `B` channels all have the same value as the original grayscale value.
+This function takes in an input single-channel grayscale `InImg`.
+The resulting output `OutImg` is still visually the same grayscale image but represented in RGB format.
+In other words, for each pixel in `OutImg`, the `R`, `G`, and `B` channels all have the same value as the original grayscale value.
 
 **Template parameters:**
 - All template parameters are automatically inferred from the input and output `Img` arguments.
@@ -74,8 +74,8 @@ vision::GRAY2RGB(InImg, OutImg);
 template <PixelType PIXEL_T_IN, PixelType PIXEL_T_OUT,
           unsigned H, unsigned W, StorageType STORAGE_IN,
           StorageType STORAGE_OUT, NumPixelsPerCycle NPPC = NPPC_1>
-void DeBayer(vision::Img<PIXEL_T_IN, H, W, STORAGE_IN, NPPC> &ImgIn,
-             vision::Img<PIXEL_T_OUT, H, W, STORAGE_OUT, NPPC> &ImgOut,
+void DeBayer(vision::Img<PIXEL_T_IN, H, W, STORAGE_IN, NPPC> &InImg,
+             vision::Img<PIXEL_T_OUT, H, W, STORAGE_OUT, NPPC> &OutImg,
              ap_uint<2> BayerFormat = 0)
 ```
 This function converts image data in Bayer format to RGB format. Bayer format is
@@ -98,9 +98,10 @@ The image below shows how the first pixels look in each bayer format:
 ### `RGB2Bayer()`
 ```cpp
 template <PixelType PIXEL_T_IN, PixelType PIXEL_T_OUT, unsigned H, unsigned W,
-          StorageType STORAGE = FIFO, NumPixelsPerCycle NPPC = NPPC_1>
-void RGB2Bayer(vision::Img<PIXEL_T_IN, H, W, STORAGE, NPPC> &ImgIn,
-               vision::Img<PIXEL_T_OUT, H, W, STORAGE, NPPC> &ImgOut)
+          StorageType STORAGE_IN = FIFO, StorageType STORAGE_OUT = FIFO,
+          NumPixelsPerCycle NPPC = NPPC_1>
+void RGB2Bayer(vision::Img<PIXEL_T_IN, H, W, STORAGE_IN, NPPC> &InImg,
+               vision::Img<PIXEL_T_OUT, H, W, STORAGE_OUT, NPPC> &OutImg)
 ```
 This function converts an image in RGB format to RGGB (`BayerFormat` 0 in DeBayer) bayer format.
 RGB2Bayer can be useful for simulating incoming camera data in your code, and can be compiled to hardware.


### PR DESCRIPTION
Both DDR writer and reader HLS modules take in a base address in DDR for write and read.  Previously the base addresses are always tied to the same value, so writer and reader are accessing the same frame simultaneously.  This can cause the read side to read a "frame" that contains pixels from different frames (because a new frame is being written while read is happening).

This commit adds a simple FrameBufferControl module such that the writer and reader will access different frames.
The FrameBufferControl module provides the base addresses for the writer and reader, and updates the addresses when the writer finishes writing a frame (takes writer_finish as input).
Each time the DDR writer finishes writing a frame to DDR, FrameBufferControl provides a new address for the DDR writer to write the next frame, and provides to the DDR reader with the address of latest frame (the frame that just got written to DDR by DDR writer).
The number of frames and each frame's byte size can be parameterized.

Also do some refactoring to `debayer.hpp` and `format_conversions.hpp`.