### PR TITLE
Removed dataflow from sin_performance example

### DIFF
--- a/math/examples/riscv_tests/icicle_kit/sin_performance/test_dma.cpp
+++ b/math/examples/riscv_tests/icicle_kit/sin_performance/test_dma.cpp
@@ -9,7 +9,7 @@
 #define N_ITER 16
 using namespace hls::math;
 
-#define N 128000
+#define N 64000
 #define THRESHOLD 0.1
 
 

--- a/math/examples/riscv_tests/icicle_kit/sin_performance/test_dma.cpp
+++ b/math/examples/riscv_tests/icicle_kit/sin_performance/test_dma.cpp
@@ -10,33 +10,28 @@
 using namespace hls::math;
 
 #define N 128000
-#define THRESHOLD 0.01
+#define THRESHOLD 0.1
+
 
 void hls_test(float n[N], float vals[N]){
-#pragma HLS function top dataflow
+#pragma HLS function top
 #pragma HLS interface default type(axi_target)
 #pragma HLS interface argument(vals) type(axi_target) num_elements(N) dma(true)
 #pragma HLS interface argument(n) type(axi_target) num_elements(N) dma(true)
-
-#ifndef __SYNTHESIS__
-  hls::FIFO<ap_fixpt<W, IW>> fifo(N);
-#else
-  hls::FIFO<ap_fixpt<W, IW>> fifo;
-#endif
-
-
+ 
+ap_fixpt<W, IW> x_temp[N];
 #pragma HLS loop pipeline
   for (int i = 0; i < N; i++){
-    ap_fixpt<W, IW> x = n[i];
-    fifo.write(x);
+    x_temp[i] = n[i];
   }
-
+ 
+ap_fixpt<W, IW> temp[N];
 #pragma HLS loop pipeline
   for (int i = 0; i < N; i++){
-    auto x = fifo.read();
-    vals[i] = sin_lut<W, IW>(x).to_double();
+    vals[i] = sin_lut<W, IW>(x_temp[i]).to_double();
   }
 }
+
 
 void cmath_test(float n[N], float vals[N]){
   for (int i = 0; i < N; i++){

--- a/math/examples/riscv_tests/icicle_kit/sin_performance/test_initiator.cpp
+++ b/math/examples/riscv_tests/icicle_kit/sin_performance/test_initiator.cpp
@@ -9,31 +9,25 @@
 #define N_ITER 16
 using namespace hls::math;
 
-#define N 2000000
-#define THRESHOLD 0.01
+#define N 128000
+#define THRESHOLD 0.1
 
 void hls_test(float n[N], float vals[N]){
-#pragma HLS function top dataflow
+#pragma HLS function top
 #pragma HLS interface default type(axi_target)
 #pragma HLS interface argument(vals) type(axi_initiator) num_elements(N)
 #pragma HLS interface argument(n) type(axi_initiator) num_elements(N)
-
-#ifndef __SYNTHESIS__
-  hls::FIFO<ap_fixpt<W, IW>> fifo(N);
-#else
-  hls::FIFO<ap_fixpt<W, IW>> fifo;
-#endif
-
+ 
+ap_fixpt<W, IW> x_temp[N];
 #pragma HLS loop pipeline
   for (int i = 0; i < N; i++){
-    ap_fixpt<W, IW> x = n[i];
-    fifo.write(x);
+    x_temp[i] = n[i];
   }
-
+ 
+ap_fixpt<W, IW> temp[N];
 #pragma HLS loop pipeline
   for (int i = 0; i < N; i++){
-    auto x = fifo.read();
-    vals[i] = sin_lut<W, IW>(x).to_double();
+    vals[i] = sin_lut<W, IW>(x_temp[i]).to_double();
   }
 }
 

--- a/math/examples/riscv_tests/icicle_kit/sin_performance/test_initiator.cpp
+++ b/math/examples/riscv_tests/icicle_kit/sin_performance/test_initiator.cpp
@@ -9,7 +9,7 @@
 #define N_ITER 16
 using namespace hls::math;
 
-#define N 128000
+#define N 64000
 #define THRESHOLD 0.1
 
 void hls_test(float n[N], float vals[N]){

--- a/math/examples/riscv_tests/icicle_kit/sin_performance/test_no_dma.cpp
+++ b/math/examples/riscv_tests/icicle_kit/sin_performance/test_no_dma.cpp
@@ -10,33 +10,26 @@
 using namespace hls::math;
 
 #define N 128000
-#define THRESHOLD 0.01
+#define THRESHOLD 0.1
 
 void hls_test(float n[N], float vals[N]){
-#pragma HLS function top dataflow
+#pragma HLS function top
 #pragma HLS interface default type(axi_target)
 #pragma HLS interface argument(vals) type(axi_target) num_elements(N) dma(false)
 #pragma HLS interface argument(n) type(axi_target) num_elements(N) dma(false)
 
-#ifndef __SYNTHESIS__
-  hls::FIFO<ap_fixpt<W, IW>> fifo(N);
-#else
-  hls::FIFO<ap_fixpt<W, IW>> fifo;
-#endif
-
-
+ap_fixpt<W, IW> x_temp[N];
 #pragma HLS loop pipeline
   for (int i = 0; i < N; i++){
-    ap_fixpt<W, IW> x = n[i];
-    fifo.write(x);
+    x_temp[i] = n[i];
   }
 
+ap_fixpt<W, IW> temp[N];
 #pragma HLS loop pipeline
   for (int i = 0; i < N; i++){
-    auto x = fifo.read();
-    vals[i] = sin_lut<W, IW>(x).to_double();
-  }	
-}
+    vals[i] = sin_lut<W, IW>(x_temp[i]).to_double();
+  }
+}	
 
 void cmath_test(float n[N], float vals[N]){
   for (int i = 0; i < N; i++){

--- a/math/examples/riscv_tests/icicle_kit/sin_performance/test_no_dma.cpp
+++ b/math/examples/riscv_tests/icicle_kit/sin_performance/test_no_dma.cpp
@@ -9,7 +9,7 @@
 #define N_ITER 16
 using namespace hls::math;
 
-#define N 128000
+#define N 64000
 #define THRESHOLD 0.1
 
 void hls_test(float n[N], float vals[N]){


### PR DESCRIPTION
Changed the Icicle Kit sin_performance example. There is a known issue with dataflow, so we have removed the "dataflow" pragma from the example. 