### PR TITLE
Updated sin_performance test for beaglev-fire

### DIFF
--- a/math/examples/riscv_tests/sin_performance/beaglev_fire/Makefile
+++ b/math/examples/riscv_tests/sin_performance/beaglev_fire/Makefile
@@ -1,3 +1,4 @@
+NAME = sin_performance
 SRCS = ../sources/test.cpp  
 
 # Root directory path for the HLS libraries. Modify as necessary. 

--- a/math/examples/riscv_tests/sin_performance/beaglev_fire/readme.md
+++ b/math/examples/riscv_tests/sin_performance/beaglev_fire/readme.md
@@ -82,10 +82,10 @@ You should install the following software:
    /usr/share/beagleboard/gateware/change-gateware.sh ~/bitstream
 
    ```
-3. Now, copy the RISC-V binary (`beaglev_fire.accel.elf` file) to your board:
+3. Now, copy the RISC-V binary (`sin_performance.accel.elf` file) to your board:
 
    ```console
-   scp ../../../math/examples/riscv_tests/sin_performance/beaglev_fire/hls_output/beaglev_fire.accel.elf beagle@192.168.0.173:
+   scp ../../../math/examples/riscv_tests/sin_performance/beaglev_fire/hls_output/sin_performance.accel.elf beagle@192.168.0.173:
    ```
 
 4. To run the executable, you will need to be running as `sudo`. Go into your board and run the binary you just copied over as sudo.


### PR DESCRIPTION
Added NAME = sin_performance to the Makefile to not use the directory name, which is the default behaviour when the NAME variable is omitted.