### PR TITLE
Update to Work with New Beagle Gateware 

### DIFF
--- a/dsp/examples/riscv_tests/fft_demo/beaglev_fire/fft_performance.yaml
+++ b/dsp/examples/riscv_tests/fft_demo/beaglev_fire/fft_performance.yaml
@@ -2,11 +2,15 @@
 HSS:
     type: git
     link: https://github.com/polarfire-soc/hart-software-services.git
-    branch: master
-    commit: v2025.03
+    branch: next
+    commit: af4f81a657c92601b0de2f52b89a3f97bbf4a2b3
+    make_clean: 0
 gateware:
-    top_level_name: shls_test
-    build-args: "M2_OPTION:NONE CAPE_OPTION:NONE SMARTHLS:../../../../../dsp/examples/riscv_tests/fft_demo/beaglev_fire"
     type: sources
-    unique-design-version:
-
+    build-args: "CAPE_OPTION:DEFAULT
+                   M2_OPTION:NONE
+             MIPI_CSI_OPTION:DEFAULT
+               SYZYGY_OPTION:DEFAULT
+                  APU_OPTION:SMARTHLS
+                      SHLS_0:../../../../../dsp/examples/riscv_tests/fft_demo/beaglev_fire"
+    unique-design-version: 7.0.0

--- a/dsp/examples/riscv_tests/fft_demo/sources/demo.cpp
+++ b/dsp/examples/riscv_tests/fft_demo/sources/demo.cpp
@@ -11,7 +11,7 @@ using namespace hls;
 using namespace hls::dsp;
 
 #include "test_vector.h"
-#include "test_utils.hpp"
+#include "../../../test_utils.hpp"
 
 struct fft_buff_t {
   uint16_t im;

--- a/math/examples/riscv_tests/sin_performance/beaglev_fire/sin_performance.yaml
+++ b/math/examples/riscv_tests/sin_performance/beaglev_fire/sin_performance.yaml
@@ -2,11 +2,15 @@
 HSS:
     type: git
     link: https://github.com/polarfire-soc/hart-software-services.git
-    branch: master
-    commit: v2025.03
+    branch: next
+    commit: af4f81a657c92601b0de2f52b89a3f97bbf4a2b3
+    make_clean: 0
 gateware:
-    top_level_name: shls_test
-    build-args: "M2_OPTION:NONE CAPE_OPTION:NONE SMARTHLS:../../../../../math/examples/riscv_tests/sin_performance/beaglev_fire"
     type: sources
-    unique-design-version:
-
+    build-args: "CAPE_OPTION:DEFAULT
+                   M2_OPTION:NONE
+             MIPI_CSI_OPTION:DEFAULT
+               SYZYGY_OPTION:DEFAULT
+                  APU_OPTION:SMARTHLS
+                      SHLS_0:../../../../../math/examples/riscv_tests/sin_performance/beaglev_fire"
+    unique-design-version: 7.0.0

--- a/math/examples/riscv_tests/sin_performance/sources/test.cpp
+++ b/math/examples/riscv_tests/sin_performance/sources/test.cpp
@@ -10,7 +10,7 @@ using namespace hls::math;
 
 #define THRESHOLD 0.1 // Error Threshold
 
-void hls_test(float n[__N_ELEM], float vals[__N_ELEM]){
+void sin_performance(float n[__N_ELEM], float vals[__N_ELEM]){
   #pragma HLS function top dataflow
   #pragma HLS interface default type(axi_target)
   #pragma HLS interface argument(vals) type(axi_initiator) num_elements(__N_ELEM)
@@ -60,7 +60,7 @@ int main(){
   double cmath1 = timestamp();
 
   double hls_math0 = timestamp();
-  hls_test(x, vals_fixpt);
+  sin_performance(x, vals_fixpt);
   double hls_math1 = timestamp();
 
   // Test accuracy of results:


### PR DESCRIPTION
(See https://openbeagle.org/beaglev-fire/gateware/-/merge_requests/177, https://openbeagle.org/beaglev-fire/gateware/-/merge_requests/172, https://openbeagle.org/beaglev-fire/gateware/-/merge_requests/178)

## Summary

SmartHLS support was added to the (official) beagle-v/gateware repo; we refactored our beagle gateware repo to match what is in main. 

- They had to add two patches to get our libraries to work. This PR makes the changes in those patches to libraries.
- Fix the .yaml files to match the one in the beagle-v/gateware repo.
- Update submodule. Note that we still don't want to point to the "official" beagle-v/gateware repo because they use Libero 2024.2, whereas we like to keep up to date w/ the latest Libero release. 

## Testing

Tested the fft example and the sin example manually. Also tested the sin-shls-apu.yaml build option inside the gateware repo manually.